### PR TITLE
subtitles and danmu coexist / 字幕与弹幕共存

### DIFF
--- a/scripts/bilibiliAssert/main.lua
+++ b/scripts/bilibiliAssert/main.lua
@@ -32,11 +32,12 @@ function assprocess()
 		string.gsub(directory, "/", "\\")
 		py_path = ''..directory..'\\Danmu2Ass.py'
 	end
-	
+	local dw = mp.get_property_osd('display-width')
+	local dh = mp.get_property_osd('display-height')
 	-- choose to use python or .exe
 	local arg = { 'python', py_path, '-d', directory, 
-	-- 设置屏幕分辨率 （默认 1920x1080)
-	'-s', '1920x1080',
+	-- 设置屏幕分辨率 （自动取值)
+	'-s', ''..dw..'x'..dh,
 	-- 设置字体大小    (默认 37.0)
 	'-fs',  '37.0',
 	-- 设置弹幕不透明度 (默认 0.95)
@@ -64,7 +65,7 @@ function assprocess()
 		then
 			log('开火')
 			-- 挂载subtitles滤镜，注意加上@标签，这样即使多次调用也不会重复挂载，以最后一次为准
-			mp.commandv('vf', 'append', '@danmu:subtitles="'..directory..'/bilibili.ass"') 
+			mp.commandv('vf', 'append', '@danmu:subtitles=filename="'..directory..'/bilibili.ass"')
 			-- 只能在软解或auto-copy硬解下生效，统一改为auto-copy硬解
 			mp.set_property('hwdec', 'auto-copy')
 		else
@@ -90,4 +91,4 @@ end
 
 
 mp.add_key_binding('b', 'toggle', asstoggle)
-mp.register_event("start-file", assprocess)
+mp.register_event("file-loaded", assprocess)

--- a/scripts/bilibiliAssert/main.lua
+++ b/scripts/bilibiliAssert/main.lua
@@ -88,7 +88,6 @@ function asstoggle()
 	assprocess()
 end
 
-if mp.get_opt('cid') ~= nil then
-	mp.add_key_binding('b',	asstoggle)
-	mp.register_event("start-file", assprocess)
-end
+
+mp.add_key_binding('b', 'toggle', asstoggle)
+mp.register_event("start-file", assprocess)

--- a/scripts/bilibiliAssert/main.lua
+++ b/scripts/bilibiliAssert/main.lua
@@ -63,10 +63,10 @@ function assprocess()
 		if err == nil
 		then
 			log('开火')
-			mp.set_property_native("options/sub-file-paths", directory)
-			mp.set_property('sub-auto', 'all')
-			mp.command('sub-reload')
-			mp.commandv('rescan_external_files','reselect')
+			-- 挂载subtitles滤镜，注意加上@标签，这样即使多次调用也不会重复挂载，以最后一次为准
+			mp.commandv('vf', 'append', '@danmu:subtitles="'..directory..'/bilibili.ass"') 
+			-- 只能在软解或auto-copy硬解下生效，统一改为auto-copy硬解
+			mp.set_property('hwdec', 'auto-copy')
 		else
 			log(err)
 		end
@@ -74,6 +74,21 @@ function assprocess()
 
 end
 
+-- toggle function
+function asstoggle()
+	-- if exists @danmu filter， remove it
+	for _, f in ipairs(mp.get_property_native('vf')) do
+		if f.label == 'danmu' then
+			log('停火')
+			mp.commandv('vf', 'remove', '@danmu')
+			return
+		end
+	end
+	-- otherwise, load danmu
+	assprocess()
+end
 
-mp.add_key_binding('b',	assprocess)
-mp.register_event("start-file", assprocess)
+if mp.get_opt('cid') ~= nil then
+	mp.add_key_binding('b',	asstoggle)
+	mp.register_event("start-file", assprocess)
+end


### PR DESCRIPTION
目前有个痛点，弹幕与字幕只能选择一个，不能同时播，\
其实mpv是支持多字幕的，使用lavfi下的subtitles滤镜可同时输出多个高级字幕，\
`vf append subtitles=filename="xxx.ass"`或者简写`vf append subtitles="xxx.ass"`\
但是有个缺点，只在软解和`auto-copy`硬解模式下有效，但是也不算多大的问题，`auto-copy`硬解是兼顾性能和兼容性的最佳选择

修改点如下：
1. 使用subtitles滤镜加载弹幕，字幕还是原生的字幕轨
2. 因为只在软解和`auto-copy`硬解模式下有效，综合考虑解码强制改为`hwdec=auto-copy`
3. 由于不能像之前一样通过切换字幕轨来关闭弹幕，快捷键`b`改为 加载/关闭 一体，如果存在弹幕就关闭，不存在就加载

[测试视频链接](https://www.bilibili.com/video/BV16h4y1B7md)，最终效果图如下，弹幕和字幕都成功加载\
![屏幕截图 2023-10-09 222613](https://github.com/itKelis/MPV-Play-BiliBili-Comments/assets/45035465/0b8bceb6-6bb5-4366-a8ee-464b51b5c3d4)

update：
假设禁用了mpv默认快捷键，mpv.conf `no-input-default-bindings`，此时快捷键b是无效的，
脚本里绑定快捷键`mp.add_key_binding()`的时候给了一个名字`toggle`，
可以手动在input.conf里自定义快捷键`KEY script-binding bilibiliAssert/toggle`，这里配置的快捷键是可生效的

update2：
显示器分辨率是可以自动获取的，`display-width`和`display-height`两个属性，
必须要开始播放之后才能取到，注册事件`mp.register_event()`从`start-file`改为`file-loaded`才行，不然会取到空值


