### PR TITLE
弹幕分辨率适应视频比例

### DIFF
--- a/scripts/bilibiliAssert/main.lua
+++ b/scripts/bilibiliAssert/main.lua
@@ -32,8 +32,14 @@ function assprocess()
 		string.gsub(directory, "/", "\\")
 		py_path = ''..directory..'\\Danmu2Ass.py'
 	end
-	local dw = mp.get_property_osd('display-width')
-	local dh = mp.get_property_osd('display-height')
+	local dw = mp.get_property_number('display-width', 1920)
+	local dh = mp.get_property_number('display-height', 1080)
+	local aspect = mp.get_property_number('width', 16) / mp.get_property_number('height', 9)
+	if aspect > dw / dh then
+		dh = math.floor(dw / aspect)
+	elseif aspect < dw / dh then
+		dw = math.floor(dh * aspect)
+	end
 	-- choose to use python or .exe
 	local arg = { 'python', py_path, '-d', directory, 
 	-- 设置屏幕分辨率 （自动取值)


### PR DESCRIPTION
目前弹幕分辨率参数`-s`直接取的屏幕分辨率，如果碰到不同比例的视频，会造成字体大小不统一。

例如屏幕是1920x1080，播放16:9的视频和2:1的视频对比，后者的弹幕字体明显更小，\
因为上下有黑边，弹幕实际能跑的分辨率只有1920x960，此时用1920x1080去生弹幕，最后的字体是从1080缩小到960的。

取到屏幕分辨率之后，还要根据视频比例计算出实际能跑弹幕的分辨率是多少，这样就保证字体大小一致了。